### PR TITLE
Use entity-encoding for potential ‘mailto:’ prefix

### DIFF
--- a/lib/jekyll/email-protect.rb
+++ b/lib/jekyll/email-protect.rb
@@ -4,13 +4,9 @@ module Jekyll
 
       # Percent-encode alphanumeric characters of an email address
       def encode_email(input)
-        input.to_s.chars.inject(String.new) do |result, char|
-          if char =~ /\p{Alnum}/
-            char.bytes.inject(result) do |result, byte|
-              result << '%%%02X' % byte
-            end
-          else
-            result << char
+        input.to_s.gsub(/(^mailto:)|\p{Alnum}+/) do |char|
+          char.bytes.inject(String.new) do |result, byte|
+            result << ($1 ? '&#%d;' : '%%%02X') % byte
           end
         end
       end

--- a/lib/jekyll/email-protect/version.rb
+++ b/lib/jekyll/email-protect/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module EmailProtect
-    VERSION = '1.0.3'
+    VERSION = '1.0.4'
   end
 end


### PR DESCRIPTION
Email addresses that are used in href attributes need to be prefixed with the ‘mailto:’ URL-scheme. It makes sense to encode this as well, to make the links go undetected by simple scrapers searching for ‘mailto:’.
