### PR TITLE
Linked companion repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Jekyll Email Protect is an email protection liquid filter which can be used to obfuscate `mailto:` links to protect an email address from spam bots.
 
+ℹ️ See Jekyll Phone Protect [here](https://github.com/jacobfv/jekyll-phone-protect).
+
 ## Installation
 
 This plugin is available as a [RubyGem][ruby-gem].


### PR DESCRIPTION
My Jekyll site needed a phone encoder, and I just felt terrible typing `{{ phone | encode_email }}` so I renamed everything in this repo to make it say "phone" instead.